### PR TITLE
Mouse usability and vim navigation keys

### DIFF
--- a/scripts/Blackbox.js
+++ b/scripts/Blackbox.js
@@ -853,18 +853,18 @@ Blackbox.prototype.switchMenu = function(forcePage)
             showHelpHint: userConfig.getValue('help_hint'),
             favoritePaths: userConfig.getMultiValue('favorites'),
             includeRegex: userConfig.getValue('include_regex'),
-            keyRebindings: {
-                'Menu-Up': userConfig.getMultiValue('keys_menu_up'),
-                'Menu-Down': userConfig.getMultiValue('keys_menu_down'),
-                'Menu-Up-Fast': userConfig.getMultiValue('keys_menu_up_fast'),
-                'Menu-Down-Fast': userConfig.getMultiValue('keys_menu_down_fast'),
-                'Menu-Left': userConfig.getMultiValue('keys_menu_left'),
-                'Menu-Right': userConfig.getMultiValue('keys_menu_right'),
-                'Menu-Open': userConfig.getMultiValue('keys_menu_open'),
-                'Menu-Undo': userConfig.getMultiValue('keys_menu_undo'),
-                'Menu-Help': userConfig.getMultiValue('keys_menu_help'),
-                'Menu-Close': userConfig.getMultiValue('keys_menu_close')
-            }
+            // keyRebindings: {
+                // 'Menu-Up': userConfig.getMultiValue('keys_menu_up'),
+                // 'Menu-Down': userConfig.getMultiValue('keys_menu_down'),
+                // 'Menu-Up-Fast': userConfig.getMultiValue('keys_menu_up_fast'),
+                // 'Menu-Down-Fast': userConfig.getMultiValue('keys_menu_down_fast'),
+                // 'Menu-Left': userConfig.getMultiValue('keys_menu_left'),
+                // 'Menu-Right': userConfig.getMultiValue('keys_menu_right'),
+                // 'Menu-Open': userConfig.getMultiValue('keys_menu_open'),
+                // 'Menu-Undo': userConfig.getMultiValue('keys_menu_undo'),
+                // 'Menu-Help': userConfig.getMultiValue('keys_menu_help'),
+                // 'Menu-Close': userConfig.getMultiValue('keys_menu_close')
+            // }
         });
     } catch (e) {
         mp.msg.error('Blackbox: '+e+'.');

--- a/scripts/modules.js/SelectionMenu.js
+++ b/scripts/modules.js/SelectionMenu.js
@@ -53,13 +53,13 @@ var SelectionMenu = function(settings)
         settings.autoCloseDelay >= 0 ? settings.autoCloseDelay : 5; // 0 = Off.
     this.autoCloseActiveAt = 0;
     this.keyBindings = { // Default keybindings.
-        'Menu-Up':{repeatable:true, keys:['up']},
-        'Menu-Down':{repeatable:true, keys:['down']},
+        'Menu-Up':{repeatable:true, keys:['up','WHEEL_UP', 'k'] },
+        'Menu-Down':{repeatable:true, keys:['down', 'WHEEL_DOWN', 'j' ]},
         'Menu-Up-Fast':{repeatable:true, keys:['shift+up']},
         'Menu-Down-Fast':{repeatable:true, keys:['shift+down']},
         'Menu-Left':{repeatable:true, keys:['left']},
         'Menu-Right':{repeatable:false, keys:['right']},
-        'Menu-Open':{repeatable:false, keys:['enter']},
+        'Menu-Open':{repeatable:false, keys:['enter', 'MBTN_LEFT']},
         'Menu-Undo':{repeatable:false, keys:['bs']},
         'Menu-Help':{repeatable:false, keys:['h']},
         'Menu-Close':{repeatable:false, keys:['esc']}

--- a/scripts/modules.js/SelectionMenu.js
+++ b/scripts/modules.js/SelectionMenu.js
@@ -57,11 +57,11 @@ var SelectionMenu = function(settings)
         'Menu-Down':{repeatable:true, keys:['down', 'WHEEL_DOWN', 'j' ]},
         'Menu-Up-Fast':{repeatable:true, keys:['shift+up']},
         'Menu-Down-Fast':{repeatable:true, keys:['shift+down']},
-        'Menu-Left':{repeatable:true, keys:['left']},
-        'Menu-Right':{repeatable:false, keys:['right']},
+        'Menu-Left':{repeatable:true, keys:['left', 'h']},
+        'Menu-Right':{repeatable:false, keys:['right', 'l']},
         'Menu-Open':{repeatable:false, keys:['enter', 'MBTN_LEFT']},
         'Menu-Undo':{repeatable:false, keys:['bs']},
-        'Menu-Help':{repeatable:false, keys:['h']},
+        'Menu-Help':{repeatable:false, keys:['?']},
         'Menu-Close':{repeatable:false, keys:['esc']}
     };
 


### PR DESCRIPTION
This is more a hack for a PR I would open an Issue for it first if it was possible

The issue: Adding multiple keyRebindings as an array is impossible, but I managed it with commenting out keyRebindings completely and setting multi keys as the default keyBindings in SelectionMenu.js. Using the mouse along with the keyboard (and vi movement keys) for selection is only what I wanted so this gets this for me but implementing multikey keyRebindings as a general functionality would be better.